### PR TITLE
Start Linking between Machine Pages and Select Page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+/.cache
 
 npm-debug.log*
 yarn-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,30 @@
         "warning": "^4.0.1"
       }
     },
+    "@material-ui/icons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.1.tgz",
+      "integrity": "sha512-1kNcxYiIT1x8iDPEAlgmKrfRTIV8UyK6fLVcZ9kMHIKGWft9I451V5mvSrbCjbf7MX1TbLWzZjph0aVCRf9MqQ==",
+      "requires": {
+        "@babel/runtime": "7.0.0",
+        "recompose": "^0.29.0"
+      },
+      "dependencies": {
+        "recompose": {
+          "version": "0.29.0",
+          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.29.0.tgz",
+          "integrity": "sha512-J/qLXNU4W+AeHCDR70ajW8eMd1uroqZaECTj6qqDLPMILz3y0EzpYlvrnxKB9DnqcngWrtGwjXY9JeXaW9kS1A==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
+        }
+      }
+    },
     "@types/jss": {
       "version": "9.5.6",
       "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.6.tgz",
@@ -6511,6 +6535,27 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "material-ui-icons": {
+      "version": "1.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/material-ui-icons/-/material-ui-icons-1.0.0-beta.36.tgz",
+      "integrity": "sha512-7rS6b2EV5QXCB/gTi/Ac9Wbxd+h9EZv1Td3rLLJe4IER8mVHRgdqZccB3EsjW2DrJ7opdY1+8X3/vyrS7CQNpg==",
+      "requires": {
+        "recompose": "^0.26.0"
+      },
+      "dependencies": {
+        "recompose": {
+          "version": "0.26.0",
+          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+          "requires": {
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "symbol-observable": "^1.0.4"
+          }
+        }
       }
     },
     "math-expression-evaluator": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^3.1.0",
+    "@material-ui/icons": "^3.0.1",
+    "material-ui-icons": "^1.0.0-beta.36",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-scripts": "1.1.5"

--- a/src/App.js
+++ b/src/App.js
@@ -9,11 +9,13 @@ class App extends React.Component {
   toMachineSelect = () => {
     this.setState({ currentPage : "machine-select",
                     currentMachine : null  });
+    document.title = "ADAM: Another Drawer of Alan's Machines"
   };
 
   toDFAHome = (title) => {
     this.setState({ currentPage : "dfa-home",
-                    currentMachine : title });
+                    currentMachine : title.toUpperCase() });
+    document.title = title;
   };
 
   render() {

--- a/src/App.js
+++ b/src/App.js
@@ -3,16 +3,18 @@ import MachineSelectPage from './pages/machine_select.js';
 import DFAHomePage from './pages/dfa_home.js'
 
 class App extends React.Component {
-  state = { currentPage : "machine-select",
-            currentMachine : null };
+  constructor() {
+    super();
+    this.toMachineSelect();
+  }
 
-  toMachineSelect = () => {
+  toMachineSelect() {
     this.setState({ currentPage : "machine-select",
                     currentMachine : null  });
     document.title = "ADAM: Another Drawer of Alan's Machines"
   };
 
-  toDFAHome = (title) => {
+  toDFAHome(title) {
     this.setState({ currentPage : "dfa-home",
                     currentMachine : title.toUpperCase() });
     document.title = title;

--- a/src/App.js
+++ b/src/App.js
@@ -1,87 +1,28 @@
 import React from "react";
-import Card from "@material-ui/core/Card";
-import CardActionArea from "@material-ui/core/CardActionArea";
-import CardActions from "@material-ui/core/CardActions";
-import CardContent from "@material-ui/core/CardContent";
-import Grid from "@material-ui/core/Grid";
-import Typography from "@material-ui/core/Typography";
-import ADAMToolbar from './toolbar.js';
+import MachineSelectPage from './pages/machine_select.js';
+import DFAHomePage from './pages/dfa_home.js'
 
-const styles = {
-  card: {
-    width: 200
-  },
-  preview_pane: {
-    marginBottom: 100,
-    fontSize: 14
-  },
-  banner: {
-    //paddingTop: 0,
-    //paddingBottom: 0
-  },
-  option: {
-    marginLeft: "auto"
-  }
-};
+class App extends React.Component {
+  state = { currentPage : "machine-select",
+            currentMachine : null };
 
-var machines = [
-  { title: "Sample DFA", type: "dfa" },
-  { title: "Sample NFA", type: "nfa" },
-  { title: "Sample TM", type: "tm" },
-  { title: "Another DFA", type: "dfa" }
-];
+  toMachineSelect = () => {
+    this.setState({ currentPage : "machine-select",
+                    currentMachine : null  });
+  };
 
-var colors = { dfa: "#7e57c2", nfa: "#ffa726", tm: "#42a5f5" };
+  toDFAHome = (title) => {
+    this.setState({ currentPage : "dfa-home",
+                    currentMachine : title });
+  };
 
-class MachineCard extends React.Component {
   render() {
-    return (
-      <div>
-      <Card style={styles.card}>
-        <CardActions
-          style={{ ...styles.banner, backgroundColor: colors[this.props.type] }}
-        >
-          <Typography variant="body2">
-            {this.props.title.toUpperCase()}
-          </Typography>
-        </CardActions>
-       {/*<Link to="/dfa_home/">*/} <CardActionArea>
-          <CardContent >
-            <Typography style={styles.preview_pane} color="textSecondary">
-              Click me to get to the machine.
-            </Typography>
-          </CardContent>
-        </CardActionArea>{/*</Link>*/}
-      </Card>
-      </div>
-    );
+    if (this.state.currentPage === "machine-select") {
+      return <MachineSelectPage todfa={this.toDFAHome} />;
+    } else {
+      return <DFAHomePage back={this.toMachineSelect} title={this.state.currentMachine} />;
+    }
   }
 }
 
-class CardGrid extends React.Component {
-  render() {
-    return (
-      <Grid container spacing={16} style={{margin:16}}>
-        {machines.map(x => (
-          <Grid item>
-            <MachineCard title={x.title} type={x.type} />
-          </Grid>
-        ))}
-      </Grid>
-    );
-  }
-}
-
-class MachineSelectPage extends React.Component {
-  render() {
-    return (
-        <div>
-          <ADAMToolbar title="Select a Machine"/>
-          <CardGrid/>
-          {/*<AddMachineButton/>*/}
-        </div>
-    );
-  }
-}
-
-export default MachineSelectPage;
+export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -3,18 +3,23 @@ import MachineSelectPage from './pages/machine_select.js';
 import DFAHomePage from './pages/dfa_home.js'
 
 class App extends React.Component {
-  constructor() {
-    super();
-    this.toMachineSelect();
+
+  constructor(props) {
+    super(props);
+    // Need to manually set state data at beginning,
+    // or else it is null for first render call
+    this.state = { currentPage : "machine-select",
+              currentMachine : null  };
+    document.title = "ADAM: Another Drawer of Alan's Machines";
   }
 
-  toMachineSelect() {
+  toMachineSelect = () => {
     this.setState({ currentPage : "machine-select",
                     currentMachine : null  });
-    document.title = "ADAM: Another Drawer of Alan's Machines"
+    document.title = "ADAM: Another Drawer of Alan's Machines";
   };
 
-  toDFAHome(title) {
+  toDFAHome = (title) => {
     this.setState({ currentPage : "dfa-home",
                     currentMachine : title.toUpperCase() });
     document.title = title;

--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -1,16 +1,26 @@
 import React from 'react';
 import AppBar from '@material-ui/core/AppBar';
 //import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import { ArrowBack } from '@material-ui/icons';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-//import { Link } from 'gatsby';
 
 class ADAMToolbar extends React.Component {
   render() {
+      var back_button = null;
+      if (this.props.back) {
+        back_button = (<IconButton style={{marginLeft: -12,marginRight: 20}}
+                        onClick={this.props.back} color="inherit">
+          <ArrowBack />
+        </IconButton>)
+      }
+
       return (
         <div style={{flexGrow: 1}}>
           <AppBar position="static">
             <Toolbar>
+              {back_button}
               <Typography variant="title" color="inherit" style={{flexGrow: 1}}>
                 {this.props.title}
               </Typography>

--- a/src/pages/dfa_home.js
+++ b/src/pages/dfa_home.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+import ADAMToolbar from '../components/toolbar';
+
+class DFAHomePage extends React.Component {
+  render() {
+    return (
+          <ADAMToolbar title={this.props.title} back={this.props.back} />
+    );
+  }
+}
+
+export default DFAHomePage;

--- a/src/pages/machine_select.js
+++ b/src/pages/machine_select.js
@@ -45,7 +45,7 @@ class MachineCard extends React.Component {
             {this.props.title.toUpperCase()}
           </Typography>
         </CardActions>
-        <CardActionArea onClick={() => this.props.todfa(this.props.title.toUpperCase())}>
+        <CardActionArea onClick={() => this.props.todfa(this.props.title)}>
           <CardContent >
             <Typography style={styles.preview_pane} color="textSecondary">
               Click me to get to the machine.

--- a/src/pages/machine_select.js
+++ b/src/pages/machine_select.js
@@ -1,0 +1,87 @@
+import React from "react";
+import Card from "@material-ui/core/Card";
+import CardActionArea from "@material-ui/core/CardActionArea";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+import ADAMToolbar from '../components/toolbar.js';
+
+const styles = {
+  card: {
+    width: 200
+  },
+  preview_pane: {
+    marginBottom: 100,
+    fontSize: 14
+  },
+  banner: {
+    //paddingTop: 0,
+    //paddingBottom: 0
+  },
+  option: {
+    marginLeft: "auto"
+  }
+};
+
+var machines = [
+  { title: "Sample DFA", type: "dfa" },
+  { title: "Sample NFA", type: "nfa" },
+  { title: "Sample TM", type: "tm" },
+  { title: "Another DFA", type: "dfa" }
+];
+
+var MachineColors = { dfa: "#7e57c2", nfa: "#ffa726", tm: "#42a5f5" };
+
+class MachineCard extends React.Component {
+  render() {
+    return (
+      <div>
+      <Card style={styles.card}>
+        <CardActions
+          style={{ ...styles.banner, backgroundColor: MachineColors[this.props.type] }}
+        >
+          <Typography variant="body2">
+            {this.props.title.toUpperCase()}
+          </Typography>
+        </CardActions>
+        <CardActionArea onClick={() => this.props.todfa(this.props.title.toUpperCase())}>
+          <CardContent >
+            <Typography style={styles.preview_pane} color="textSecondary">
+              Click me to get to the machine.
+            </Typography>
+          </CardContent>
+        </CardActionArea>
+      </Card>
+      </div>
+    );
+  }
+}
+
+class CardGrid extends React.Component {
+  render() {
+    return (
+      <Grid container spacing={16} style={{margin:16}}>
+        {machines.map(x => (
+          <Grid item>
+            <MachineCard title={x.title} type={x.type} todfa={this.props.todfa}/>
+          </Grid>
+        ))}
+      </Grid>
+    );
+  }
+}
+
+class MachineSelectPage extends React.Component {
+  render() {
+    return (
+        <div>
+          <ADAMToolbar title="Select a Machine" />
+          <CardGrid todfa={this.props.todfa}/>
+          {/*<AddMachineButton/>*/}
+        </div>
+    );
+  }
+}
+
+export default MachineSelectPage;


### PR DESCRIPTION
This commit is the start of the Machine View page. Adds links
from machine cards on select page to Machine View page (dfa_home.js),
as well as back button from Machine View page to select page.

This commit also adds pages and components directories to src to better
organize and modularize code.

Dependency of @material_ui/icons/ was added, which is reflected in
modifications to package.json and package-lock.json.

Addresses #4