### PR TITLE
Add Options Button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,8 +8,10 @@ class App extends React.Component {
     super(props);
     // Need to manually set state data at beginning,
     // or else it is null for first render call
-    this.state = { currentPage : "machine-select",
-              currentMachine : null  };
+    this.state = {
+      currentPage : "machine-select",
+      currentMachine : null,
+    };
     document.title = "ADAM: Another Drawer of Alan's Machines";
   }
 

--- a/src/pages/machine_select.js
+++ b/src/pages/machine_select.js
@@ -1,11 +1,22 @@
-import React from "react";
-import Card from "@material-ui/core/Card";
-import CardActionArea from "@material-ui/core/CardActionArea";
-import CardActions from "@material-ui/core/CardActions";
-import CardContent from "@material-ui/core/CardContent";
-import Grid from "@material-ui/core/Grid";
-import Typography from "@material-ui/core/Typography";
+import React from 'react';
+
 import ADAMToolbar from '../components/toolbar.js';
+
+import AddIcon from '@material-ui/icons/Add';
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Card from '@material-ui/core/Card';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Grid from '@material-ui/core/Grid';
+import List from '@material-ui/core/List';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Typography from '@material-ui/core/Typography';
 
 const styles = {
   card: {
@@ -23,13 +34,6 @@ const styles = {
     marginLeft: "auto"
   }
 };
-
-var machines = [
-  { title: "Sample DFA", type: "dfa" },
-  { title: "Sample NFA", type: "nfa" },
-  { title: "Sample TM", type: "tm" },
-  { title: "Another DFA", type: "dfa" }
-];
 
 var MachineColors = { dfa: "#7e57c2", nfa: "#ffa726", tm: "#42a5f5" };
 
@@ -62,7 +66,7 @@ class CardGrid extends React.Component {
   render() {
     return (
       <Grid container spacing={16} style={{margin:16}}>
-        {machines.map(x => (
+        {this.props.machines.map(x => (
           <Grid item>
             <MachineCard title={x.title} type={x.type} todfa={this.props.todfa}/>
           </Grid>
@@ -72,13 +76,91 @@ class CardGrid extends React.Component {
   }
 }
 
+class NewMachineDialog extends React.Component {
+  render() {
+    const { classes, onClose, selectedValue, ...other } = this.props;
+    let smallText = (string) => <p style={{fontSize:"85%"}}>{string}</p>;
+
+    return (
+      <Dialog onClose={this.props.onClose} aria-labelledby="simple-dialog-title" {...other}>
+        <DialogTitle id="simple-dialog-title">Select a Machine Type</DialogTitle>
+        <div>
+          <List>
+            <ListItem button onClick={() => { this.props.addMachine("dfa"); this.props.onClose(); }}>
+              <ListItemAvatar>
+                <Avatar style={{backgroundColor: MachineColors["dfa"]}} children={smallText("DFA")} />
+              </ListItemAvatar>
+              <ListItemText primary="New DFA"/>
+            </ListItem>
+            <ListItem button onClick={() => { this.props.addMachine("nfa"); this.props.onClose(); }}>
+              <ListItemAvatar>
+              <Avatar style={{backgroundColor: MachineColors["nfa"]}} children={smallText("NFA")}   />
+              </ListItemAvatar>
+              <ListItemText primary="New NFA"/>
+            </ListItem>
+            <ListItem button onClick={() => { this.props.addMachine("tm"); this.props.onClose(); }}>
+              <ListItemAvatar>
+              <Avatar style={{backgroundColor: MachineColors["tm"]}} children={smallText("TM")} />
+              </ListItemAvatar>
+              <ListItemText primary="New Turing Machine"/>
+            </ListItem>
+          </List>
+        </div>
+      </Dialog>
+    );
+  }
+}
+
+class AddMachineButton extends React.Component {
+  state = { open: false };
+
+  handleOpen = () => {
+    this.setState({ open: true, });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
+  render() {
+    return (
+      <div>
+        <Button onClick={this.handleOpen} variant="fab" color="primary"
+                style={{ right: 20, bottom: 20, position: 'fixed'}}>
+          <AddIcon />
+        </Button>
+        <NewMachineDialog open={this.state.open} onClose={this.handleClose} addMachine={this.props.addMachine} />
+      </div>
+    );
+  }
+}
+
 class MachineSelectPage extends React.Component {
+  state = {
+    machines: [
+      { title: "Sample DFA", type: "dfa" },
+      { title: "Sample NFA", type: "nfa" },
+      { title: "Sample TM", type: "tm" },
+      { title: "Another DFA", type: "dfa" }
+    ]
+  }
+
+  addMachine = (type) => {
+    this.setState((prevState, props) => {
+      return {
+        machines: prevState.machines.concat([
+            { title: `New ${type}`, type: type }
+        ])
+      };
+    });
+  };
+
   render() {
     return (
         <div>
           <ADAMToolbar title="Select a Machine" />
-          <CardGrid todfa={this.props.todfa}/>
-          {/*<AddMachineButton/>*/}
+          <CardGrid todfa={this.props.todfa} machines={this.state.machines}/>
+          <AddMachineButton addMachine={this.addMachine}/>
         </div>
     );
   }

--- a/src/pages/machine_select.js
+++ b/src/pages/machine_select.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import ADAMToolbar from '../components/toolbar.js';
+import IconButton from "@material-ui/core/IconButton";
+import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
 
 import AddIcon from '@material-ui/icons/Add';
 import Avatar from '@material-ui/core/Avatar';
@@ -27,8 +29,8 @@ const styles = {
     fontSize: 14
   },
   banner: {
-    //paddingTop: 0,
-    //paddingBottom: 0
+    paddingTop: 0,
+    paddingBottom: 0
   },
   option: {
     marginLeft: "auto"
@@ -48,6 +50,12 @@ class MachineCard extends React.Component {
           <Typography variant="body2">
             {this.props.title.toUpperCase()}
           </Typography>
+          <IconButton
+          style={styles.option}
+          onClick={() => {window.location.href = "https://www.youtube.com/watch?v=rEq1Z0bjdwc"}}
+          >
+            <MoreHorizIcon />
+          </IconButton>
         </CardActions>
         <CardActionArea onClick={() => this.props.todfa(this.props.title)}>
           <CardContent >


### PR DESCRIPTION
Add an options button to the upper right corner of machine cards. This
will allow the user to uncover more actions related to the card. For
now, clicking on the button simply causes the button to introduce itself
to the user.

Addresses #13.

Signed-off-by: Grant Iraci <grantira@buffalo.edu>