### PR TITLE
Add Edit Button

### DIFF
--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import AppBar from '@material-ui/core/AppBar';
-//import Button from '@material-ui/core/Button';
+import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import { ArrowBack } from '@material-ui/icons';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -21,9 +21,14 @@ class ADAMToolbar extends React.Component {
           <AppBar position="static">
             <Toolbar>
               {back_button}
-              <Typography variant="title" color="inherit" style={{flexGrow: 1}}>
+              <Typography variant="title" color="inherit" style={{marginRight: 50}}>
                 {this.props.title}
               </Typography>
+              {this.props.btns ? this.props.btns.map(x => (
+                <Button color="inherit" onClick = {x.onClick}>
+                  {x.body}
+                </Button>
+              )) : null}
             </Toolbar>
           </AppBar>
         </div>

--- a/src/pages/dfa_home.js
+++ b/src/pages/dfa_home.js
@@ -5,7 +5,9 @@ import ADAMToolbar from '../components/toolbar';
 class DFAHomePage extends React.Component {
   render() {
     return (
-          <ADAMToolbar title={this.props.title} back={this.props.back} />
+          <ADAMToolbar title={this.props.title} back={this.props.back} btns={[
+            {body : "EDIT", onClick : () => {window.location.href = "https://www.youtube.com/watch?v=90KpM-ojTX4&t=29"}}
+          ]} />
     );
   }
 }


### PR DESCRIPTION
Add an edit button to the toolbar of the machine view page. Updates the
ToolBar class to allow the insertion of buttons into the toolbar with
customizable text and onClick action handlers. Also adds a small blank
space between toolbar title and buttons to clearly distinguish them from
each other.

Update machine view toolbar to have an edit button. Currently clicking
the edit button merely informs the user they have clicked it.

Addresses #32.

Signed-off-by: Grant Iraci <grantira@buffalo.edu>