### PR TITLE
Add Edit View Page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import MachineSelectPage from './pages/machine_select.js';
 import DFAHomePage from './pages/dfa_home.js'
+import EditPage from './pages/machine_edit.js'
 
 class App extends React.Component {
 
@@ -15,6 +16,12 @@ class App extends React.Component {
     document.title = "ADAM: Another Drawer of Alan's Machines";
   }
 
+  toEdit = (title) => {
+    this.setState({ currentPage : "machine-edit",
+                    currentMachine : title.toUpperCase() });
+    document.title = title;
+  };
+
   toMachineSelect = () => {
     this.setState({ currentPage : "machine-select",
                     currentMachine : null  });
@@ -28,10 +35,16 @@ class App extends React.Component {
   };
 
   render() {
+    console.log(this.state.currentPage)
     if (this.state.currentPage === "machine-select") {
       return <MachineSelectPage todfa={this.toDFAHome} />;
-    } else {
-      return <DFAHomePage back={this.toMachineSelect} title={this.state.currentMachine} />;
+    }
+    else if (this.state.currentPage === "machine-edit"){
+      return <EditPage  />
+    } 
+    else {
+      return <DFAHomePage back={this.toMachineSelect} title={this.state.currentMachine} 
+	edit={() => {this.toEdit(this.state.currentMachine)}}/>;
     }
   }
 }

--- a/src/pages/dfa_home.js
+++ b/src/pages/dfa_home.js
@@ -6,7 +6,7 @@ class DFAHomePage extends React.Component {
   render() {
     return (
           <ADAMToolbar title={this.props.title} back={this.props.back} btns={[
-            {body : "EDIT", onClick : () => {window.location.href = "https://www.youtube.com/watch?v=90KpM-ojTX4&t=29"}}
+            {body : "EDIT", onClick : this.props.edit} 
           ]} />
     );
   }

--- a/src/pages/machine_edit.js
+++ b/src/pages/machine_edit.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+import ADAMToolbar from '../components/toolbar';
+
+class EditPage extends React.Component {
+  render() {
+    return (
+          <ADAMToolbar title="EDIT" />
+    );
+  }
+}
+
+export default EditPage;
+


### PR DESCRIPTION
Add page for edit view. Add functionality to edit button on machine view page so that it
navigates to the edit view page. Currently the edit page features only a toolbar with the title
EDIT. No other functionality.
Addresses #33

Signed-off-by: Kira Ashton <kiraasht@buffalo.edu>
Signed-off-by: Grant Iraci <grantira@buffalo.edu>