### PR TITLE
Edit Page Back Button

### DIFF
--- a/src/pages/machine_edit.js
+++ b/src/pages/machine_edit.js
@@ -5,7 +5,7 @@ import ADAMToolbar from '../components/toolbar';
 class EditPage extends React.Component {
   render() {
     return (
-          <ADAMToolbar title="EDIT" />
+          <ADAMToolbar title="EDIT" back={this.props.back} />
     );
   }
 }


### PR DESCRIPTION
Add back button to edit page, give back button functionality. Back button takes user to the
machine view page for the machine they had selected to edit.
Addresses #34

Signed-off-by: Kira Ashton <kiraasht@buffalo.edu>
Signed-off-by: Grant Iraci <grantira@buffalo.edu>